### PR TITLE
card de produto e listagem de produtos

### DIFF
--- a/src/app/pages/listagem-produtos/listagem-produtos.component.html
+++ b/src/app/pages/listagem-produtos/listagem-produtos.component.html
@@ -1,1 +1,25 @@
-<p>{{ valorPesquisa }}</p>
+<app-header />
+
+<main>
+  <div class="panel">
+    <p class="valorPesquisa">{{ valorPesquisa }}</p>
+    @if (produtosPesquisa.length > 0) {
+      @if (produtosPesquisa.length == 1) {
+        <p>1 produto encontrado.</p>
+      } @else {
+        <p>{{ produtosPesquisa.length}} produtos encontrados.</p>
+      }
+    } @else {
+      <p>Nenhum produto encontrado.</p>
+    }
+    <div class="produtos">
+      @if (produtosPesquisa.length > 0) {
+        @for (produto of produtosPesquisa; track produto.id) {
+          <app-card [produto]="produto" />
+        }
+      }
+    </div>
+  </div>
+</main>
+
+<app-footer />

--- a/src/app/pages/listagem-produtos/listagem-produtos.component.scss
+++ b/src/app/pages/listagem-produtos/listagem-produtos.component.scss
@@ -1,0 +1,38 @@
+main {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  min-height: 50vh;
+  padding: 50px;
+
+  .panel {
+    flex: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    border: 1px solid #e5e7eb;
+    padding: 10px;
+    border-radius: 10px;
+    max-width: 1400px;
+    gap: 10px;
+
+    p {
+      margin: 5px;
+    }
+
+    .valorPesquisa {
+      font-size: 1.1em;
+      font-weight: 500;
+      margin-top: 15px;
+    }
+
+    .produtos {
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      gap: 20px;
+    }
+  }
+}

--- a/src/app/pages/listagem-produtos/listagem-produtos.component.ts
+++ b/src/app/pages/listagem-produtos/listagem-produtos.component.ts
@@ -5,7 +5,6 @@ import {FooterComponent} from "../../shared/components/footer/footer.component";
 import {ProdutosService} from "../../shared/services/produtos/produtos.service";
 import {Produto} from "../../shared/interfaces/produto/produto";
 import {FormsModule} from "@angular/forms";
-import {PanelModule} from "primeng/panel";
 import {CardModule} from "primeng/card";
 import {Button} from "primeng/button";
 import {CardComponent} from "../../shared/components/card/card.component";
@@ -17,7 +16,6 @@ import {CardComponent} from "../../shared/components/card/card.component";
     HeaderComponent,
     FooterComponent,
     FormsModule,
-    PanelModule,
     CardModule,
     Button,
     RouterLink,

--- a/src/app/pages/listagem-produtos/listagem-produtos.component.ts
+++ b/src/app/pages/listagem-produtos/listagem-produtos.component.ts
@@ -1,22 +1,68 @@
 import {Component, OnInit} from '@angular/core';
-import {ActivatedRoute} from "@angular/router";
+import {ActivatedRoute, RouterLink} from "@angular/router";
+import {HeaderComponent} from "../../shared/components/header/header.component";
+import {FooterComponent} from "../../shared/components/footer/footer.component";
+import {ProdutosService} from "../../shared/services/produtos/produtos.service";
+import {Produto} from "../../shared/interfaces/produto/produto";
+import {FormsModule} from "@angular/forms";
+import {PanelModule} from "primeng/panel";
+import {CardModule} from "primeng/card";
+import {Button} from "primeng/button";
+import {CardComponent} from "../../shared/components/card/card.component";
 
 @Component({
   selector: 'app-listagem-produtos',
   standalone: true,
-  imports: [],
+  imports: [
+    HeaderComponent,
+    FooterComponent,
+    FormsModule,
+    PanelModule,
+    CardModule,
+    Button,
+    RouterLink,
+    CardComponent
+  ],
   templateUrl: './listagem-produtos.component.html',
   styleUrl: './listagem-produtos.component.scss'
 })
 export class ListagemProdutosComponent implements OnInit {
   valorPesquisa = '';
+  produtos: Produto[] = [];
 
-  constructor(private route: ActivatedRoute) {}
+  constructor(
+    private route: ActivatedRoute,
+    private produtosService: ProdutosService
+  ) {}
 
   ngOnInit() {
     this.route.queryParams.subscribe(
       params => {
         this.valorPesquisa = params['q'] || '';
+      }
+    );
+
+    this.produtosService.getTodosProtutos().subscribe(
+      (produtos) => {
+        this.produtos = produtos;
+      }
+    );
+  }
+
+  get produtosPesquisa() {
+    const palavras = this.valorPesquisa.toLowerCase().split('/(\s+)/');
+
+    return this.produtos.filter(
+      (produto) => {
+        const nomeProduto = produto.nome.toLowerCase();
+
+        for (const palavra of palavras) {
+          if (!nomeProduto.includes(palavra)) {
+            return false;
+          }
+        }
+
+        return true;
       }
     );
   }

--- a/src/app/shared/components/card/card.component.html
+++ b/src/app/shared/components/card/card.component.html
@@ -1,1 +1,48 @@
-<p>card works!</p>
+<div
+  class="card"
+>
+  <img
+    [src]="produto.imagem"
+    [alt]="produto.nome"
+    (click)="onClick()"
+  >
+
+  <hr>
+
+  <div class="content">
+    <div class="divNome">
+      <span class="nome" (click)="onClick()">{{ produto.nome }}</span>
+    </div>
+
+    @if (produto.desconto) {
+      <div>
+        <span class="precoAnterior" (click)="onClick()">{{ produto.preco | displayPreco }}</span>
+      </div>
+
+      <div class="descontoDiv">
+        <span class="preco" (click)="onClick()">{{ getPrecoDesconto(produto) | displayPreco }}</span>
+        <span class="desconto" (click)="onClick()">{{ getDescontoPorcentagem(produto) }}</span>
+      </div>
+    } @else {
+      <div>
+        <span class="preco" (click)="onClick()">{{ produto.preco | displayPreco }}</span>
+      </div>
+    }
+
+    <div class="buttons">
+      <p-button
+        label="Comprar"
+        size="small"
+        icon="pi pi-shopping-bag"
+        (onClick)="onComprar()"
+      />
+      <p-button
+        label="Carrinho"
+        size="small"
+        icon="pi pi-cart-arrow-down"
+        [outlined]="true"
+        (onClick)="onCarrinho()"
+      />
+    </div>
+  </div>
+</div>

--- a/src/app/shared/components/card/card.component.scss
+++ b/src/app/shared/components/card/card.component.scss
@@ -1,0 +1,72 @@
+.card {
+  box-sizing: border-box;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 3px 20px -10px rgba(189,189,189,1);
+  transition: box-shadow 0.3s ease-in-out;
+  width: 300px;
+  border-radius: 10px;
+  padding: 0 0 15px 0;
+
+  img {
+    width: 300px;
+    height: 300px;
+    object-fit: contain;
+    cursor: pointer;
+  }
+
+  span {
+    cursor: pointer;
+  }
+
+  hr {
+    border: 1px solid #e5e7eba0;
+    width: 100%;
+    margin: 0 0 15px 0;
+  }
+
+  .content {
+    padding: 0 15px;
+
+    .nome {
+      font-size: 1.05em;
+    }
+
+    .divNome {
+      margin: 10px 0;
+    }
+
+    .preco {
+      font-size: 1.6em;
+      font-weight: 500;
+    }
+
+    .precoAnterior {
+      font-size: 0.8em;
+      text-decoration: line-through;
+      color: dimgray;
+    }
+
+    .descontoDiv {
+      display: flex;
+      align-items: center;
+    }
+
+    .desconto {
+      color: green;
+      font-weight: 400;
+      margin-left: 10px;
+    }
+
+    .buttons {
+      display: flex;
+      gap: 10px;
+      margin-top: 15px;
+      justify-content: space-around;
+    }
+  }
+}
+
+.card:hover {
+  box-shadow: 0 3px 20px 0 rgba(189,189,189,1);
+  transition: box-shadow 0.3s ease-in-out;
+}

--- a/src/app/shared/components/card/card.component.ts
+++ b/src/app/shared/components/card/card.component.ts
@@ -1,12 +1,45 @@
-import { Component } from '@angular/core';
+import {Component, Input} from '@angular/core';
+import {Router, RouterLink} from "@angular/router";
+import {Produto} from "../../interfaces/produto/produto";
+import {DisplayPrecoPipe} from "../../pipes/display-preco/display-preco.pipe";
+import {Button} from "primeng/button";
 
 @Component({
   selector: 'app-card',
   standalone: true,
-  imports: [],
+  imports: [
+    RouterLink,
+    DisplayPrecoPipe,
+    Button
+  ],
   templateUrl: './card.component.html',
   styleUrl: './card.component.scss'
 })
 export class CardComponent {
+  @Input({required: true}) produto!: Produto;
 
+  constructor(private router: Router) {}
+
+  getPrecoDesconto(produto: Produto) {
+    return produto.preco * (1 - produto.desconto);
+  }
+
+  getDescontoPorcentagem(produto: Produto) {
+    return `${produto.desconto * 100}% OFF`;
+  }
+
+  onClick() {
+    this.router.navigate(
+      ['/detalhes'],
+      { queryParams: { produto: this.produto.id } }
+    );
+  }
+
+  onComprar() {
+    // TODO
+  }
+
+  onCarrinho() {
+    // TODO
+  }
 }

--- a/src/app/shared/interfaces/produto/produto.ts
+++ b/src/app/shared/interfaces/produto/produto.ts
@@ -1,0 +1,10 @@
+export interface Produto {
+  "id": string,
+  "nome": string,
+  "imagem": string,
+  "descricao": string,
+  "preco": number,
+  "unidadeDisponiveis": number,
+  "promocao": boolean,
+  "desconto": number
+}

--- a/src/app/shared/pipes/display-preco/display-preco.pipe.spec.ts
+++ b/src/app/shared/pipes/display-preco/display-preco.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { DisplayPrecoPipe } from './display-preco.pipe';
+
+describe('DisplayPrecoPipe', () => {
+  it('create an instance', () => {
+    const pipe = new DisplayPrecoPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/shared/pipes/display-preco/display-preco.pipe.ts
+++ b/src/app/shared/pipes/display-preco/display-preco.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'displayPreco',
+  standalone: true
+})
+export class DisplayPrecoPipe implements PipeTransform {
+
+  transform(preco: number): string {
+    return `R$ ${preco.toFixed(2).replaceAll('.', ',')}`;
+  }
+
+}

--- a/src/app/shared/services/produtos/produtos.service.ts
+++ b/src/app/shared/services/produtos/produtos.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import {Produto} from "../../interfaces/produto/produto";
 
 @Injectable({
   providedIn: 'root'
@@ -8,12 +9,12 @@ import { HttpClient } from '@angular/common/http';
 export class ProdutosService {
 
   constructor(private httpClient: HttpClient) { }
-  
+
   getTodosProtutos() {
-    return this.httpClient.get(`http://localhost:3000/produtos`)
+    return this.httpClient.get<Produto[]>(`http://localhost:3000/produtos`)
   }
 
   getProtutoId(id: string) {
-    return this.httpClient.get(`http://localhost:3000/produtos/${id}`)
+    return this.httpClient.get<Produto>(`http://localhost:3000/produtos/${id}`)
   }
 }

--- a/src/database/database.json
+++ b/src/database/database.json
@@ -7,7 +7,7 @@
       "descricao": "O iPhone 13 tem uma tela superbrilhante projetada para ser resistente. Faz vídeos com qualidade de cinema. Seu chip tem uma velocidade impressionante. E ganhou um aumento notável em bateria.",
       "preco": 3499,
       "unidadeDisponiveis": 3,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -17,7 +17,7 @@
       "descricao": "É realmente deslumbrante. O display Super AMOLED de 6,5 polegadas do Galaxy A25 5G expressa imagens com riqueza de cores e detalhes e até 1.000 nits de brilho aprimorado com Vision Booster para visibilidade e nitidez ao ar livre. E mais, o Eye Comfort Shield reduz a luz azul prejudicial, cuidando dos seus olhos de dia e à noite.",
       "preco": 1329,
       "unidadeDisponiveis": 6,
-      "promoção": true,
+      "promocao": true,
       "desconto": 0.2
     },
     {
@@ -27,7 +27,7 @@
       "descrição": "O futuro está nas suas mãos com o incrível smartphone Moto g84 5G da Motorola! Com um poderoso processador Snapdragon 695 Octa-core, 8gb de RAM e um genoroso armazenamento de 256GB, este dispositivo foi projetado para oferecer desempenho excepcional em cada tarefa que você realizar.",
       "preco": 1484,
       "unidadeDisponiveis": 1,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -37,7 +37,7 @@
       "descrição": "Descubra infinitas possibilidades para suas fotos com as 3 câmeras principais de sua equipe. Teste sua criatividade e jogue com iluminação, diferentes planos e efeitos para obter ótimos resultados.",
       "preco": 3199,
       "unidadeDisponiveis": 2,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -47,7 +47,7 @@
       "descrição": "A Máquina de Lavar 14kg Electrolux Essential Care com Cesto Inox 127v, equipada com cesto de aço inoxidável e dispenser exclusivo Jet&Clean, foi projetada para simplificar as tarefas domésticas relacionadas à lavagem de roupas. A tecnologia Jet&Clean da Electrolux, presente nesta máquina, garante uma distribuição uniforme de sabão e amaciante, evitando manchas e relavagens, enquanto o novo Ultra Filter Pega Fiapos oferece uma capacidade de retenção de sujeira oito vezes maior.",
       "preco": 1899,
       "unidadeDisponiveis": 9,
-      "promoção": true,
+      "promocao": true,
       "desconto": 0.1
     },
     {
@@ -57,7 +57,7 @@
       "descrição": "Roupas limpas e bem cuidadas facilitam no dia a dia, ainda mais se você tiver um produto que não dá trabalho e economiza energia, água e sabão. Com o Tanquinho Colormaq 10kg você lava suas roupas com mais eficiência. Ele possui batedor gigante no fundo, filtro de fiapos, tampa translúcida, cinco programas de lavagem e intervalos para molho. A entrada e saída de água são manuais, sendo assim é preciso desencaixar a mangueira e esperar a água escoar.",
       "preco": 509,
       "unidadeDisponiveis": 15,
-      "promoção": true,
+      "promocao": true,
       "desconto": 0.4
     },
     {
@@ -67,7 +67,7 @@
       "descrição": "Proporciona mais praticidade e eficiência com capacidade para até 15 cafezinhos e filtro permanente removível para limpeza. Possui sistema corta-pingo que permite a retirada da jarra enquanto o café está sendo preparado. O reservatório de água com graduação indica o nível de água, prático e simples.",
       "preco": 98,
       "unidadeDisponiveis": 21,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -77,7 +77,7 @@
       "descrição": "Você está procurando aquecer salas pequenas? Manter seus ambiente aquecidos durante o inverno não é mais um problema. O aquecedor elétrico Ventisol AH permite que você aproveite sua casa durante todo o ano de uma forma mais prática e simples.",
       "preco": 175,
       "unidadeDisponiveis": 3,
-      "promoção": true,
+      "promocao": true,
       "desconto": 0.1
     },
     {
@@ -87,7 +87,7 @@
       "descrição": "O Copo De Liquidificador Mondial L-850 L-900w Cristal Preto da marca Micromax é a escolha perfeita para a sua cozinha. Com uma capacidade de 1500 mL, este liquidificador é ideal para preparar sucos, vitaminas, molhos e muito mais. O modelo é compatível com Mondial L-850 L-900W Cristal Preto, proporcionando um design elegante e sofisticado que combina com qualquer decoração de cozinha. Além disso, o copo de cristal preto é resistente e durável, garantindo um uso prolongado. Não perca a oportunidade de ter um produto de alta qualidade que facilitará o seu dia a dia na cozinha.",
       "preco": 40,
       "unidadeDisponiveis": 44,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -97,7 +97,7 @@
       "descrição": "Se a sua cozinha é pequena, o forno de mesa é a melhor solução. Você desfrutará das mesmas vantagens que um forno convencional e ganhará praticidade e conforto.",
       "preco": 593,
       "unidadeDisponiveis": 28,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -107,7 +107,7 @@
       "descrição": "A Jaqueta Casaco Masculina Bobojaco Gominho Frio Corta Vento é a escolha ideal para homens que valorizam estilo e funcionalidade durante os dias mais frios. Esta peça não apenas protege contra o vento e o frio, mas também se destaca pela sua durabilidade e conforto.",
       "preco": 78,
       "unidadeDisponiveis": 9,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -117,7 +117,7 @@
       "descrição": "O Monitor Led 21.5'' 22b1hm5 Aoc, foi projetado para entregar conteúdo de qualidade com excelente transmissão de imagem. Possuindo ótima visibilidade com seu ângulo de visão de 178º/178º graças à tecnologia do Painel VA.",
       "preco": 480,
       "unidadeDisponiveis": 13,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -127,7 +127,7 @@
       "descrição": "Jogo de lençol casal padrão cama 3 peças 400 fios toque aveludado. Ideal para cama box de casal padrão.",
       "preco": 40,
       "unidadeDisponiveis": 19,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -137,7 +137,7 @@
       "descrição": "Desperte seus sentidos com o Café Pilão Espresso Grão 1kg, uma escolha perfeita para apreciadores de café que buscam qualidade e sabor autêntico. Este café é cuidadosamente selecionado e possui um nível de torra médio, ideal para quem aprecia um sabor equilibrado e uma textura suave. Os grãos são 100% puros e torrados na medida certa para garantir o máximo de sabor e aroma.",
       "preco": 77,
       "unidadeDisponiveis": 7,
-      "promoção": true,
+      "promocao": true,
       "desconto": 0.1
     },
     {
@@ -147,7 +147,7 @@
       "descrição": "O Alicate Universal Gedore Profissional é a ferramenta perfeita para qualquer trabalho. Com cabo emborrachado em CRV, proporciona conforto e segurança durante o uso. Sua cabeça antiderrapante garante um agarre firme em qualquer superfície. Este modelo é novo e da renomada marca Gedore, sinônimo de qualidade e durabilidade.",
       "preco": 40,
       "unidadeDisponiveis": 3,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -157,7 +157,7 @@
       "descrição": "Por ser sem fio, você terá uma versatilidade incomparável para levar o produto para qualquer lugar e chegar nos cantos mais difíceis de limpar.",
       "preco": 189,
       "unidadeDisponiveis": 26,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -167,7 +167,7 @@
       "descrição": "Air Fryer New Pratic AF-31 da Mondial na cor preta, com tecnologia de circulação de ar que permite fritar alimentos sem uso de óleo. Possui cesto removível com capacidade de 3,5L e potência de 1500W, ideal para o preparo de refeições. Inclui timer de 60 minutos, aviso sonoro com desligamento automático e cesto antiaderente.",
       "preco": 269,
       "unidadeDisponiveis": 1,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -177,7 +177,7 @@
       "descrição": "Essa Taça de Vinho conta com a mais avançada tecnologia, com a parede fina em cristal e design elegante para melhorar a sua experiência ao degustar um bom vinho.",
       "preco": 129,
       "unidadeDisponiveis": 2,
-      "promoção": true,
+      "promocao": true,
       "desconto": 0.25
     },
     {
@@ -187,7 +187,7 @@
       "descrição": "A pesca magnética é semelhante a caça de objetos de metais como deita com detector de metais onde os objetos são descobertos, podendo alcançar uma profundeza ainda maior. Composição. Aço Inox e imã de neodímio.",
       "preco": 159,
       "unidadeDisponiveis": 6,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     },
     {
@@ -197,7 +197,7 @@
       "descrição": "Chegou a hora de mostrar seu jogo e ser considerado o craque da galera. A Penalty criou a nova Bola Campo Bravo XXIV, seu design inovador e suas cores facilitam na visualização durante o domínio da bola!",
       "preco": 78,
       "unidadeDisponiveis": 11,
-      "promoção": false,
+      "promocao": false,
       "desconto": 0
     }
   ],


### PR DESCRIPTION
Criei o card de produtos e a página de listagem de produtos. Como um depende do outro, achei prudente criar os dois ao mesmo tempo.

Eu criei uma interface Produto e alterei o ProdutosService para retornar objetos desta interface. Eu também alterei a propriedade `promocao` dos produtos na `database.json` pois estava `promoção` com cedilha e til, e a minha IDE estava reclamando.

Criei um pipe DisplayPreço para exibir os preços dos produtos nos cards.

Eu tive dificuldade em usar alguns componentes do PrimeNG, acabei criando a maior parte da estilização na mão mesmo. Se vocês quiserem melhorar depois, fiquem à vontade.

Ao clicar nos elementos do card do produto ele redireciona para a página de detalhes, com a query param `produto`, sendo o id do produto.

Eu também adicionei os botões Comprar e Carrinho, mas não implementei a funcionalidade pois a tela de carrinho ainda não foi criada. A ideia é que o botão Comprar adiciona o produto ao carrinho e redireciona o usuário ao carrinho pare ele finalizar a compra, e o botão Carrinho adiciona o produto ao carrinho sem redirecionar a página.